### PR TITLE
Fix footer year and font format

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,7 +4,7 @@
 
 @font-face {
   font-family: 'Ndot55';
-  src: url('/fonts/Ndot55.otf') format('truetype');
+  src: url('/fonts/Ndot55.otf') format('opentype');
   font-weight: normal;
   font-style: normal;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -281,7 +281,7 @@ export default function Home() {
       {/* Footer */}
       <footer className="border-muted mt-24 px-4 py-6 text-muted font-body text-sm">
         <div className="max-w-5xl mx-auto flex flex-col sm:flex-row justify-between items-center gap-4">
-          <span>© 2025 Aniket Raj</span>
+          <span>© {year} Aniket Raj</span>
           <div className="space-x-6">
             <a href="#" className="hover:text-foreground transition">
               Home


### PR DESCRIPTION
## Summary
- use dynamic year in footer
- correct font format for Ndot55

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_684fe3a813d0833091681baae1edb72d